### PR TITLE
Add bottleneck dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy==1.18.1
+Bottleneck==1.3.2
 pandas==0.25.1
 scikit-learn==0.23.1
 tensorflow==1.15.2


### PR DESCRIPTION
The Python script `expomf.py` in the `models` directory fails without this dependency.